### PR TITLE
switch to elasticsearch 6.8.5 as the default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Within the packer directory, create a file called `variables.json` and fill it i
 
 ```
 {
-  "elasticsearch_version": "5.6.12"
+  "elasticsearch_version": "6.8.5"
 }
 ```
 

--- a/pelias-elasticsearch.json
+++ b/pelias-elasticsearch.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "elasticsearch_version": "5.6.12",
+    "elasticsearch_version": "6.8.5",
     "aws_access_key": "",
     "aws_secret_key": "",
     "subnet_id": ""

--- a/scripts/default.sh
+++ b/scripts/default.sh
@@ -2,6 +2,9 @@
 
 export DEBIAN_FRONTEND=noninteractive
 
+# https://github.com/hashicorp/packer/issues/41
+sleep 30
+
 sudo apt-get update
 sudo apt-get upgrade -y
 

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -2,7 +2,7 @@
 
 cd
 
-git clone https://github.com/orangejulius/elasticsearch-bash-utils
+git clone https://github.com/geocodeearth/elasticsearch-bash-utils
 
 sudo cp elasticsearch-bash-utils/es_diagnostic.sh /usr/local/bin/ || true
 sudo chmod uo+x /usr/local/bin/es_diagnostic.sh || true


### PR DESCRIPTION
This PR is currently for testing only but can later be merged to enable ES6 as the default Pelias version.