### PR TITLE
Elasticsearch 7 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Within the packer directory, create a file called `variables.json` and fill it i
 
 ```
 {
-  "elasticsearch_version": "6.8.5"
+  "elasticsearch_version": "7.5.1"
 }
 ```
 

--- a/pelias-elasticsearch.json
+++ b/pelias-elasticsearch.json
@@ -55,10 +55,6 @@
     },
     {
       "type": "shell",
-      "script": "scripts/java.sh"
-    },
-    {
-      "type": "shell",
       "script": "scripts/elasticsearch.sh",
       "environment_vars": [
         "ELASTICSEARCH_VERSION={{user `elasticsearch_version`}}"

--- a/pelias-elasticsearch.json
+++ b/pelias-elasticsearch.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "elasticsearch_version": "6.8.5",
+    "elasticsearch_version": "7.5.1-amd64",
     "aws_access_key": "",
     "aws_secret_key": "",
     "subnet_id": ""

--- a/scripts/default.sh
+++ b/scripts/default.sh
@@ -12,7 +12,7 @@ sleep 30
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
-sudo apt-get install htop dstat jq -y
+sudo apt-get install htop dstat jq awscli -y
 
 echo "elasticsearch soft nofile 128000
 elasticsearch hard nofile 128000

--- a/scripts/java.sh
+++ b/scripts/java.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -ex
-
-export DEBIAN_FRONTEND=noninteractive
-
-sudo apt-get install openjdk-8-jre -y


### PR DESCRIPTION
This PR adds Elasticsearch 7 support.

In order to do so, the following changes are made:
  - installation of the JVM is **removed**. ES7 comes with its own bundled JVM, so we might as well just use that
  - The [AWS CLI](https://aws.amazon.com/cli/) client is installed. This is now required by startup code as Elasticsearch 7 requires all master eligible nodes to be listed in the configuration of _each_ node.

Connects https://github.com/pelias/pelias/issues/831