### PR TITLE
Use G1GC Garbage Collector

### DIFF
--- a/scripts/elasticsearch.sh
+++ b/scripts/elasticsearch.sh
@@ -21,3 +21,10 @@ cd /usr/share/elasticsearch/bin
 sudo ./elasticsearch-plugin install --verbose --batch analysis-icu
 sudo ./elasticsearch-plugin install --verbose --batch repository-s3
 sudo ./elasticsearch-plugin install --verbose --batch discovery-ec2
+
+# enable the G1GC garbage collector on JVM10+
+# https://medium.com/naukri-engineering/garbage-collection-in-elasticsearch-and-the-g1gc-16b79a447181
+sudo sed -i 's/# 10-:-XX:-UseConcMarkSweepGC/10-:-XX:-UseConcMarkSweepGC/g' /etc/elasticsearch/jvm.options
+sudo sed -i 's/# 10-:-XX:-UseCMSInitiatingOccupancyOnly/10-:-XX:-UseCMSInitiatingOccupancyOnly/g' /etc/elasticsearch/jvm.options
+sudo sed -i 's/# 10-:-XX:+UseG1GC/10-:-XX:+UseG1GC/g' /etc/elasticsearch/jvm.options
+sudo sed -i 's/# 10-:-XX:InitiatingHeapOccupancyPercent=75/10-:-XX:InitiatingHeapOccupancyPercent=75/g' /etc/elasticsearch/jvm.options


### PR DESCRIPTION
From https://github.com/pelias/packer-elasticsearch/pull/3:

The G1GC garbage collector has been available for years now but the ES
folk have waited about 4 years for it to mature before they gave it
their blessings. There is still some contention around universal support
and enabling it by default in ES but these shouldn't affect us as we're
only targeting standard hardware and Posix OS's. The default CMS garbage
collector is considered the best choice for general use-cases, the G1GC
collector can help reduce long GC cycles.

See https://medium.com/naukri-engineering/garbage-collection-in-elasticsearch-and-the-g1gc-16b79a447181