### PR TITLE
Update default Elasticsearch version to 7.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Within the packer directory, create a file called `variables.json` and fill it i
 
 ```
 {
-  "elasticsearch_version": "7.5.1-amd64"
+  "elasticsearch_version": "7.16.1-amd64"
 }
 ```
 

--- a/pelias-elasticsearch.json
+++ b/pelias-elasticsearch.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "elasticsearch_version": "7.5.1-amd64",
+    "elasticsearch_version": "7.16.1-amd64",
     "aws_access_key": "",
     "aws_secret_key": "",
     "subnet_id": ""


### PR DESCRIPTION
This version contains fixes for the log4j security vulnerability.

See https://github.com/pelias/pelias/issues/921