### PR TITLE
Update AMI to Ubuntu 20

### DIFF
--- a/pelias-elasticsearch.json
+++ b/pelias-elasticsearch.json
@@ -4,7 +4,7 @@
     "aws_access_key": "",
     "aws_secret_key": "",
     "subnet_id": "",
-    "source_ami_name": "*ubuntu-bionic-18.04-amd64-server-*",
+    "source_ami_name": "*ubuntu-focal-20.04-amd64-server-*",
     "instance_type": "c5.large"
   },
   "builders": [{


### PR DESCRIPTION
Since Ubuntu 18 has been EOL for a while, the default should be at least version 20

:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
